### PR TITLE
Use correct splatting

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
@@ -387,11 +387,7 @@ function Export-TargetResource
         foreach ($Case in $Cases)
         {
             Write-Host "    GDPR: [$i/$($Cases.Count)] $($Case.Name)" -NoNewline
-            $Params = @{
-                Name       = $Case.Name
-                Credential = $Credential
-            }
-            $Results = Get-TargetResource @Params
+            $Results = Get-TargetResource @PSBoundParameters -Name $Case.Name
             $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
                 -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
@@ -523,9 +523,10 @@ function Export-TargetResource
         foreach ($action in $actions)
         {
             Write-Host "        |---[$i/$($actions.Length)] $($action.Name)" -NoNewline
-            $Params = $PSBoundParameters.Clone()
-            $Params.Action = $action.Action
-            $Params.SearchName = $action.SearchName
+            $Params = @{
+                Action = $action.Action
+                SearchName = $action.SearchName
+            }
 
             $Scenario = Get-ResultProperty -ResultString $action.Results -PropertyName 'Scenario'
 
@@ -533,7 +534,7 @@ function Export-TargetResource
             {
                 $Params.Action = 'Retention'
             }
-            $Results = Get-TargetResource @Params
+            $Results = Get-TargetResource @PSBoundParameters @Params
             $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
                 -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
@@ -565,7 +566,6 @@ function Export-TargetResource
                 $Params = @{
                     Action     = $action.Action
                     SearchName = $action.SearchName
-                    Credential = $Credential
                 }
 
                 $Scenario = Get-ResultProperty -ResultString $action.Results -PropertyName 'Scenario'
@@ -574,7 +574,7 @@ function Export-TargetResource
                 {
                     $Params.Action = 'Retention'
                 }
-                $Results = Get-TargetResource @Params
+                $Results = Get-TargetResource @PSBoundParameters @Params
                 $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
                     -Results $Results
                 $dscContent += Get-M365DSCExportContentForResource -ResourceName $ResourceName `


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes additional Get-TargetResource calls from SCComplianceCase and SCComplianceSearchAction to use @PSBoundParameters and removes $PSBoundParameters.Clone() from SCComplianceSearchAction

#### This Pull Request (PR) fixes the following issues
None
